### PR TITLE
Fixes AccessDenied error on site collection creation

### DIFF
--- a/AutoSPInstallerFunctions.ps1
+++ b/AutoSPInstallerFunctions.ps1
@@ -7703,7 +7703,7 @@ Function Stop-DefaultWebsite ()
     # Added to avoid conflicts with web apps that do not use a host header
     # Thanks to Paul Stork per http://autospinstaller.codeplex.com/workitem/19318 for confirming the Stop-Website cmdlet
     ImportWebAdministration
-    $defaultWebsite = Get-Website | Where-Object {$_.Name -eq "Default Web Site" -or $_.ID -eq 1 -or $_.physicalPath -eq "%SystemDrive%\inetpub\wwwroot"} # Try different ways of identifying the Default Web Site, in case it has a different name (e.g. localized installs)
+    $defaultWebsite = Get-Website | Where-Object {$_.Name -eq "Default Web Site" -or $_.physicalPath -eq "%SystemDrive%\inetpub\wwwroot"} # Try different ways of identifying the Default Web Site, in case it has a different name (e.g. localized installs)
     Write-Host -ForegroundColor White " - Checking $($defaultWebsite.Name)..." -NoNewline
     if ($defaultWebsite.State -ne "Stopped")
     {


### PR DESCRIPTION
If there are no IIS sites prior to SharePoint installation (e.g., "Default Web Site" was removed) then "SharePoint Web Services" IIS site will be created with ID = 1.
On new site collection creation, Stop-DefaultWebsite function wrongly assumes that IIS site with ID = 1 is the "Default Web Site" and stops it, which results in hard-to-debug issue (AccessDenied as SecurityTokenService is not available anymore).
If really needed I can write function to check IIS bindings for site with ID = 1, or at minimum, check if site name is "SharePoint Web Services", but imho it's kind of stupid to stop any site with ID = 1 (what if it's some business app or WebAPI which uses its own port and do not interfere with SP).