### PR TITLE
Correct the use of SPServices to run the C2WTS.

### DIFF
--- a/SP/Automation/AutoSPInstallerInput.xml
+++ b/SP/Automation/AutoSPInstallerInput.xml
@@ -153,11 +153,30 @@
       </ServerRoles>
         <!-- The ManagedAccounts section configures all accounts that will be added to SharePoint as managed accounts. -->
         <ManagedAccounts>
-            <!-- The CommonName values should remain unchanged for these first 4 accounts; you can add additional managed accounts, but the script expects certain static values for the CommonName of these 4 managed accounts.
+            <!-- The CommonName values should remain unchanged for these first 5 accounts; you can add additional managed accounts, but the script expects certain static values for the CommonName of these 4 managed accounts.
                  If you are creating additional web applications, use a new account for each web application with a new common name, unless you are creating a large number
                  of web applications, in which case the additional memory consumption this requires outweighs the security benefits. -->
             <ManagedAccount CommonName="spservice">
                 <Username>CONTOSO\SP_Services</Username>
+                <Password></Password>
+            </ManagedAccount>
+			<!-- 
+				The Claims to Windows Token Service requires special permissions on each server.
+				
+				Member of Local Administrators (Handled by AutoSPInstaller)
+				
+				The following is a manual process to be done by you, the API To adjust these is not yet available.
+				
+				Local Security Policies (secpol.msc):
+					Act as part of the operating system.
+					Impersonate a user after authentication.
+					Log on as a service.
+					
+				SharePoint will not automatically grant these for you, you must set them yourself.
+				This account is a HIGH privilege account and should be kept very safe.
+			-->
+			<ManagedAccount CommonName="spclaims">
+                <Username>CONTOSO\SP_Claims</Username>
                 <Password></Password>
             </ManagedAccount>
             <ManagedAccount CommonName="Portal">

--- a/SP/Automation/AutoSPInstallerModule.psm1
+++ b/SP/Automation/AutoSPInstallerModule.psm1
@@ -1759,9 +1759,9 @@ Function GetSecureFarmPassphrase ([xml]$xmlInput)
 # Func: UpdateProcessIdentity
 # Desc: Updates the account a specified service runs under to the general app pool account
 # ====================================================================================
-Function UpdateProcessIdentity ($serviceToUpdate)
-{
-    $spservice = Get-SPManagedAccountXML $xmlInput -CommonName "spservice"
+Function UpdateProcessIdentity ($serviceToUpdate, $managedAccountName = "spservice")
+{	
+    $spservice = Get-SPManagedAccountXML $xmlInput -CommonName $managedAccountName
     # Managed Account
     $managedAccountGen = Get-SPManagedAccount | Where-Object {$_.UserName -eq $($spservice.username)}
     if ($managedAccountGen -eq $null) { Throw " - Managed Account $($spservice.username) not found" }
@@ -2489,7 +2489,7 @@ Function ConfigureSandboxedCodeService ([xml]$xmlInput)
             Try
             {
                 Write-Host -ForegroundColor White " - Starting Microsoft SharePoint Foundation Sandboxed Code Service..."
-                UpdateProcessIdentity $sandboxedCodeService
+                UpdateProcessIdentity -serviceToUpdate $sandboxedCodeService
                 $sandboxedCodeService.Update()
                 $sandboxedCodeService.Provision()
                 If (-not $?) {Throw " - Failed to start Sandboxed Code Service"}
@@ -3498,7 +3498,7 @@ Function CreateUserProfileServiceApplication ([xml]$xmlInput)
                             Write-Host -ForegroundColor White " - Deleting existing sync credentials timer job..."
                             $UPSCredentialsJob.Delete()
                         }
-                        UpdateProcessIdentity $profileSyncService
+                        UpdateProcessIdentity -serviceToUpdate $profileSyncService
                         $profileSyncService.Update()
                         Write-Host -ForegroundColor White " - Waiting for User Profile Synchronization Service..." -NoNewline
                         # Provision the User Profile Sync Service
@@ -4113,7 +4113,7 @@ Function CreateWebAnalyticsApp ([xml]$xmlInput)
             $analyticsDataProcessingInstances = Get-SPServiceInstance | Where-Object {$_.GetType().ToString() -eq "Microsoft.Office.Server.WebAnalytics.Administration.WebAnalyticsServiceInstance"}
             $analyticsDataProcessingInstance = $analyticsDataProcessingInstances | Where-Object {MatchComputerName $_.Server.Address $env:COMPUTERNAME}
             If (-not $?) { Throw " - Failed to find Analytics Data Processing Service instance" }
-            UpdateProcessIdentity $analyticsDataProcessingInstance
+            UpdateProcessIdentity -serviceToUpdate $analyticsDataProcessingInstance
             $analyticsDataProcessingInstance.Update()
             Write-Host -ForegroundColor White " - Starting local Analytics Data Processing Service instance..."
             $analyticsDataProcessingInstance.Provision()
@@ -4307,9 +4307,7 @@ Function ConfigureClaimsToWindowsTokenService ([xml]$xmlInput)
                 Write-Host -ForegroundColor White " - Starting $($claimsService.DisplayName)..."
                 if ($xmlInput.Configuration.Farm.Services.ClaimsToWindowsTokenService.UpdateAccount -eq $true)
                 {
-                    UpdateProcessIdentity $claimsService
-                    $claimsService.Update()
-                    # Add C2WTS account (currently the generic service account) to local admins
+					# Add C2WTS account to local admins
                     $builtinAdminGroup = Get-AdministratorsGroup
                     $adminGroup = ([ADSI]"WinNT://$env:COMPUTERNAME/$builtinAdminGroup,group")
                     # This syntax comes from Ying Li (http://myitforum.com/cs2/blogs/yli628/archive/2007/08/30/powershell-script-to-add-remove-a-domain-user-to-the-local-administrators-group-on-a-remote-machine.aspx)
@@ -4322,6 +4320,9 @@ Function ConfigureClaimsToWindowsTokenService ([xml]$xmlInput)
                         Write-Host -ForegroundColor White " - Adding $($managedAccountGen.Username) to local Administrators..."
                         ([ADSI]"WinNT://$env:COMPUTERNAME/$builtinAdminGroup,group").Add("WinNT://$managedAccountDomain/$managedAccountUser")
                     }
+					
+                    UpdateProcessIdentity -serviceToUpdate $claimsService -managedAccountName $spservice
+                    $claimsService.Update()
                 }
                 $claimsService.Provision()
                 $claimsService | Start-SPServiceInstance
@@ -4416,7 +4417,7 @@ Function ConfigureFoundationSearch ([xml]$xmlInput)
         Try
         {
             $foundationSearchService = (Get-SPFarm).Services | Where-Object {$_.Name -eq "SPSearch4"}
-            UpdateProcessIdentity $foundationSearchService
+            UpdateProcessIdentity -serviceToUpdate $foundationSearchService
         }
         Catch
         {
@@ -4472,7 +4473,7 @@ Function ConfigureTracing ([xml]$xmlInput)
         }
         Try
         {
-            UpdateProcessIdentity $spTraceV4
+            UpdateProcessIdentity -serviceToUpdate $spTraceV4
         }
         Catch
         {
@@ -4586,7 +4587,7 @@ Function ConfigureDistributedCacheService ([xml]$xmlInput)
             Write-Host -ForegroundColor White " - Applying service account $($spservice.username) to service AppFabricCachingService..."
             Try
             {
-                UpdateProcessIdentity $distributedCachingSvc
+                UpdateProcessIdentity -serviceToUpdate $distributedCachingSvc
             }
             Catch
             {
@@ -6481,7 +6482,7 @@ Function CreateProjectServerServiceApp ([xml]$xmlInput)
             $projectServiceInstances = (Get-SPFarm).Services | Where-Object {$_.GetType().ToString() -eq $projectService}
             foreach ($projectServiceInstance in $projectServiceInstances)
             {
-                UpdateProcessIdentity $projectServiceInstance
+                UpdateProcessIdentity -serviceToUpdate $projectServiceInstance
             }
         }
         # Create a Project Server DB (2013 only)


### PR DESCRIPTION
The SPServices account is not the right account to be running the claims to windows token service as.  The C2WTS account requires very special elevated permissions and adding the Services account to local admins will result in warnings displayed in the health analyzer.  Unfortunately I don't yet know how to automate configuring of local security policies as it is very low level from what I can google currently... however this is a much better step in the right direction of informing the user they need a specific account with very high risk permissions.